### PR TITLE
Support passing in things by object rather than by ID.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Trello"
 uuid = "d200c542-ce20-11e9-2772-a79080e7011a"
 authors = ["Lyndon White"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/api.jl
+++ b/src/api.jl
@@ -29,46 +29,50 @@ function create_board(cred::TrelloCred, name; desc="", id_organization="")
 end
 
 """
-    delete_board(cred::TrelloCred, id)
+    delete_board(cred::TrelloCred, board_id|board)
 
 Deletes the board.
 """
-delete_board(cred::TrelloCred, id) = delete_request(cred, "/1/boards/$id")
+delete_board(cred::TrelloCred, board_id::AbstractString) = delete_request(cred, "/1/boards/$board_id")
+delete_board(cred::TrelloCred, board) = delete_board(cred, board.id)
 
 
 """
-    create_list(credit::TrelloCred, board_id, name, pos="bottom")
+    create_list(credit::TrelloCred, board_id|board, name, pos="bottom")
 
 Create a list within the given board, with the given `name`,
 at position given by `pos`
 """
-function create_list(cred::TrelloCred, board_id, name, pos="bottom")
+function create_list(cred::TrelloCred, board_id::AbstractString, name, pos="bottom")
     resp = post_request(cred, "/1/boards/$(board_id)/lists"; name=name, pos=pos)
     return resp
 end
+create_list(cred::TrelloCred, board, args...) = create_list(cred, board.id, args...)
 
 """
-    get_lists(cred::TrelloCred, board_id)
+    get_lists(cred::TrelloCred, board_id|board)
 
 Get all the lists within a given Trello board.
 """
-function get_lists(cred::TrelloCred, board_id)
+function get_lists(cred::TrelloCred, board_id::AbstractString)
     raw = get_request(cred, "/1/boards/$(board_id)/lists")
     return indexed_collection(sortbypos(filteroutclosed(raw)))
 end
+get_lists(cred::TrelloCred, board) = get_lists(cred, board.id)
 
 """
-    get_labels(cred::TrelloCred, board_id)
+    get_labels(cred::TrelloCred, board_id|board)
 
 Get all the labels within a given Trello board.
 """
-function get_labels(cred::TrelloCred, board_id)
+function get_labels(cred::TrelloCred, board_id::AbstractString)
     raw = get_request(cred, "/1/boards/$(board_id)/labels")
     return indexed_collection(raw)
 end
+get_labels(cred::TrelloCred, board) = get_labels(cred, board.id)
 
 """
-    create_card(cred::TrelloCred, list_id, name; desc="", label_ids::Vector=[])
+    create_card(cred::TrelloCred, list_id|list, name; desc="", label_ids::Vector=[])
 
 Create a card, on the given list with the name, description and labels as specified.
 
@@ -76,7 +80,7 @@ See Trello docs:
  - https://developers.trello.com/reference#cards-2
  - https://api.trello.com/1/cards?idList=idList&keepFromSource=all
 """
-function create_card(cred::TrelloCred, list_id, name; desc="", label_ids::Vector=[])
+function create_card(cred::TrelloCred, list_id::AbstractString, name; desc="", label_ids::Vector=[])
     return post_request(cred, "/1/cards";
         idList=list_id,
         name =name,
@@ -84,15 +88,18 @@ function create_card(cred::TrelloCred, list_id, name; desc="", label_ids::Vector
         idLabels = join(label_ids, ",")
     )
 end
+function create_card(cred::TrelloCred, list, args...; kwargs...)
+    return create_card(cred, list.id, args...; kwargs...)
+end
 
 """
-    get_cards(cred::TrelloCred, list_id)
+    get_cards(cred::TrelloCred, list_id|list)
 
 Returns all the cards on a given list.
 """
-function get_cards(cred::TrelloCred, list_id)
+function get_cards(cred::TrelloCred, list_id::AbstractString)
     raw = get_request(cred, "/1/lists/$(list_id)/cards")
     cards = sortbypos(filteroutclosed(raw))
     return indexed_collection(cards)
 end
-
+get_cards(cred::TrelloCred, list) = get_cards(cred, list.id)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,39 +5,55 @@ using UUIDs
 @testset "Trello.jl" begin
 
     cred = TrelloCred()
+    @testset "End to End Usage" begin
+        new_board_name = "ZZ_testing_$(uuid1())"
 
-    new_board_name = "ZZ_testing_$(uuid1())"
+        # Should be able to create boards:
+        new_board = create_board(cred, new_board_name; desc="testing")
+        boards = get_boards(cred)
+        @test haskey(boards, new_board_name)
+        board = boards[new_board_name]
+        @test board.desc == "testing"
+        board_id = boards[new_board_name].id
 
-    # Should be able to create boards:
-    create_board(cred::TrelloCred, new_board_name; desc="testing")
-    boards = get_boards(cred)
-    @test haskey(boards, new_board_name)
-    @test boards[new_board_name].desc == "testing"
-    board_id = boards[new_board_name].id
+        # the resturn from `create_board` at least has same key fields as can be read from `get_boards`
+        @test new_board.id == board.id
+        @test new_board.name == board.name
+        
+        # Test labels
+        @test isempty(get_labels(cred, board_id))
+
+        # Should be able to create lists
+        create_list(cred, board_id, "L1")
+        create_list(cred, board_id, "L2")
+        create_list(cred, board, "L3")  # not passing ID but passing the board object
+
+        lists = get_lists(cred, board_id)
+        @test collect(keys(lists)) == ["L1", "L2", "L3"]
+        list = lists["L2"]
+        list_id = list.id
+
+        # Test cards
+        create_card(cred, list_id, "C1")
+        create_card(cred, list_id, "C2")
+        create_card(cred, list, "C3")  # not passing ID but passing the list object
+
+        cards = get_cards(cred, list_id)
+        @test get_cards(cred, list) == cards   # same result wether using list_id or list object
+        @test collect(keys(cards)) == ["C1", "C2", "C3"]
 
 
-    # Test labels
-    @test isempty(get_labels(cred, board_id))
+        # After deleting board should be gone
+        delete_board(cred, board_id)
+        @test !haskey(get_boards(cred), new_board_name)
+    end
 
-    # Should be able to create lists
-    create_list(cred, board_id, "L1")
-    create_list(cred, board_id, "L2")
-    create_list(cred, board_id, "L3")
-
-    lists = get_lists(cred, board_id)
-    @test collect(keys(lists)) == ["L1", "L2", "L3"]
-    list_id = lists["L2"].id
-
-    # Test cards
-    create_card(cred, list_id, "C1")
-    create_card(cred, list_id, "C2")
-    create_card(cred, list_id, "C3")
-
-    cards = get_cards(cred, list_id)
-    @test collect(keys(cards)) == ["C1", "C2", "C3"]
-
-
-    # After deleting board should be gone
-    delete_board(cred, board_id)
-    @test !haskey(get_boards(cred), new_board_name)
+    @testset "delete_board by board object" begin
+        new_board_name = "YY_testing_$(uuid1())"
+        # Should be able to create boards:
+        board = create_board(cred, new_board_name)
+        @test haskey(get_boards(cred), new_board_name)
+        delete_board(cred, board)
+        @test !haskey(get_boards(cred), new_board_name)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,16 +19,20 @@ using UUIDs
         # the resturn from `create_board` at least has same key fields as can be read from `get_boards`
         @test new_board.id == board.id
         @test new_board.name == board.name
-        
+
         # Test labels
         @test isempty(get_labels(cred, board_id))
+        @test isempty(get_labels(cred, board))  # not passing ID but passing the board object
 
         # Should be able to create lists
         create_list(cred, board_id, "L1")
         create_list(cred, board_id, "L2")
         create_list(cred, board, "L3")  # not passing ID but passing the board object
 
+        # should be able to get all the lists
         lists = get_lists(cred, board_id)
+        @test lists == get_lists(cred, board)  # not passing ID but passing the board object
+
         @test collect(keys(lists)) == ["L1", "L2", "L3"]
         list = lists["L2"]
         list_id = list.id


### PR DESCRIPTION
Basically under this change anytime we need an ID,
if we were not passed in a string we try to read the an `id` field from whatever we were passed.

This is convient because can use whole objects as are returned.
Like
```julia
board=create_board(cred, ...)
list = create_list(cred, board)
```
rather than having to do:
```julia
board=create_board(cred, ...)
list = create_list(cred, board.id,...)
```

This takes out friction and makes it easier to chain operations